### PR TITLE
Enable JIT compilation for AITER paged attention

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,7 @@
 [submodule "3rdparty/spdlog"]
 	path = 3rdparty/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "3rdparty/aiter"]
+	path = 3rdparty/aiter
+	url = https://github.com/rocm/aiter
+	branch = dev/testx

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,3 @@
 [submodule "3rdparty/spdlog"]
 	path = 3rdparty/spdlog
 	url = https://github.com/gabime/spdlog.git
-[submodule "3rdparty/aiter"]
-	path = 3rdparty/aiter
-	url = https://github.com/rocm/aiter
-	branch = dev/testx

--- a/flashinfer/jit/aiter_decode_templ.py
+++ b/flashinfer/jit/aiter_decode_templ.py
@@ -68,6 +68,215 @@ typedef struct _B8x16
 
 using floatx4   = __attribute__((__vector_size__(4 * sizeof(float)))) float;
 
+template <int we, int wm, typename T, bool negative_zero_nan, bool clip>
+  DEVICE_IF_HIPCC uint8_t to_float8(T _x, bool stoch = false,
+                                        uint32_t rng = 0)
+  {
+    constexpr bool is_half = std::is_same<T, _Float16>::value;
+    constexpr bool is_float = std::is_same<T, float>::value;
+    static_assert(wm + we == 7, "wm+we==7");
+    static_assert(is_half || is_float, "Only half and float can be cast to f8");
+
+    const int mfmt = (sizeof(T) == 4) ? 23 : 10;
+    uint32_t x;
+    if (sizeof(T) == 4)
+    {
+      x = reinterpret_cast<uint32_t &>(_x);
+    }
+    else
+    {
+      x = reinterpret_cast<uint16_t &>(_x);
+    }
+
+    uint32_t head, mantissa;
+    int exponent, bias;
+    uint32_t sign;
+
+    if (sizeof(T) == 4)
+    {
+      head = x & 0xFF800000;
+      mantissa = x & 0x7FFFFF;
+      exponent = (head >> 23) & 0xFF;
+      sign = head >> 31;
+      bias = 127;
+    }
+    else
+    {
+      head = x & 0xFC00;
+      mantissa = x & 0x3FF;
+      exponent = (head >> 10) & 0x1F;
+      sign = head >> 15;
+      bias = 15;
+    }
+
+    uint32_t signed_inf = (sign << 7) + (((1 << we) - 1) << wm);
+
+    // Deal with inf and NaNs
+    if (negative_zero_nan)
+    {
+      if (sizeof(T) == 4)
+      {
+        if ((x & 0x7F800000) == 0x7F800000)
+        {
+          return 0x80;
+        }
+      }
+      else
+      {
+        // if(__hisinf(x) || __hisnan(x))
+        if ((x & 0x7C00) == 0x7C00)
+        {
+          return 0x80;
+        }
+      }
+    }
+    else
+    {
+      if (sizeof(T) == 4)
+      {
+        if ((x & 0x7F800000) == 0x7F800000)
+        {
+          return signed_inf + (mantissa != 0 ? 1 : 0);
+        }
+      }
+      else
+      {
+        if ((x & 0x7C00) == 0x7C00)
+        {
+          return signed_inf + (mantissa != 0 ? 1 : 0);
+        }
+      }
+    }
+    if (x == 0)
+    {
+      return 0;
+    }
+
+    // First need to check if it is normal or denorm as there is a difference of
+    // implicit 1 Then need to adjust the exponent to align with the F8 exponent,
+    // in the meanwhile, shift The mantissa. Then for stochastic rounding, add rng
+    // to mantissa and truncate. And for RNE, no need to add rng. Then probably
+    // need to check whether there is carry and adjust exponent and mantissa again
+
+    // For IEEE bias mode, the bias is 2^(k-1) -1 where k is the width of exponent
+    // bits
+    const int f8_bias = (1 << (we - 1)) - 1 + (negative_zero_nan ? 1 : 0);
+    const int f8_denormal_act_exponent =
+        1 - f8_bias; // actual exponent of f8 denormal
+    // act_exponent is the actual exponent of fp32/fp16 (after subtracting bias)
+    // f8_exponent is the converted f8 exponent with bias encoding
+    // exponent_diff is the diff between fp32/fp16 exponent and f8 exponent,
+    // the difference needs to be adjusted and mantissa shifted
+    int act_exponent, f8_exponent, exponent_diff;
+
+    if (exponent == 0)
+    { // fp32/fp16 is in denormal.
+      /* fp32 denormal is below 2^-127 so it is usually not a concern here, we
+  mostly concern fp16 here. In this case, f8 is usually in denormal. But there
+  could be exceptions. fp16 denormal has exponent bias 15 while bf8 with NANOO has
+  exponent bias 16. It means that there are some numbers in fp16 denormal but they
+  are bf8 (NANOO) normals - smallest bf8 (NANOO) normal is 2^-15. fp16 numbers
+  where exponent==0 (actual exponent -14) and highest bit of mantissa is 1 are bf8
+  (NANOO) normal. In this case, the fp16 mantissa should be shift left by 1  */
+      act_exponent = exponent - bias + 1;
+      exponent_diff =
+          f8_denormal_act_exponent -
+          act_exponent; // actual exponent is exponent-bias+1 as it is denormal
+    }
+    else
+    { // fp32/fp16 is normal with implicit 1
+      act_exponent = exponent - bias;
+      if (act_exponent <= f8_denormal_act_exponent)
+      {
+        /* This is the case where fp32/fp16 is normal but it is in f8 denormal
+  range. For example fp8 nanoo mode, denormal exponent is -7, but if the
+  fp32/fp16 actual exponent is -7, it is actually larger due to the implicit 1,
+  Therefore it needs to be adjust to -6 and mantissa shift right by 1.
+  So for fp32/fp16, exponent -8 is the cut point to convert to fp8 nanoo */
+        exponent_diff = f8_denormal_act_exponent - act_exponent;
+      }
+      else
+      {                    // both fp32/fp16 and f8 are in normal range
+        exponent_diff = 0; // exponent_diff=0 does not mean there is no
+                           // difference for this case, act_exponent could be
+                           // larger. Just that it does not need shift mantissa
+      }
+      mantissa += (1 << mfmt); // Add the implicit 1 into mantissa
+    }
+
+    bool midpoint = (mantissa & ((1 << (mfmt - wm + exponent_diff)) - 1)) ==
+                    static_cast<uint32_t>(1 << (mfmt - wm + exponent_diff - 1));
+    /* This part is a bit tricky. The judgment of whether it is a tie needs to be
+   done before we shift right as shift right could rip off some residual part
+   and make something not midpoint look like midpoint. For example, the fp16
+   number 0x1002 (0 00100 0000000010), it is larger than midpoint, but after
+   shift right by 4 bits, it would look like midpoint.
+  */
+
+    if (exponent_diff > 0)
+    {
+      mantissa >>= exponent_diff;
+    }
+    else if (exponent_diff == -1)
+    {
+      mantissa <<= -exponent_diff;
+    }
+    bool implicit_one = mantissa & (1 << mfmt);
+    // if there is no implicit 1, it  means the f8 is denormal and need to adjust
+    // to denorm exponent
+    f8_exponent = (act_exponent + exponent_diff) /*actual f8 exponent*/ +
+                  f8_bias - (implicit_one ? 0 : 1);
+
+    // Now we have the exponent and mantissa adjusted
+    uint32_t drop_mask = (1 << (mfmt - wm)) - 1;
+    bool odd = mantissa & (1 << (mfmt - wm)); // if the least significant bit
+                                              // that is not truncated is 1
+    mantissa +=
+        (stoch ? rng : (midpoint ? (odd ? mantissa : mantissa - 1) : mantissa)) &
+        drop_mask;
+
+    // Now we deal with overflow
+    if (f8_exponent == 0)
+    {
+      if ((1 << mfmt) & mantissa)
+      {
+        f8_exponent = 1; // denormal overflow to become normal, promote exponent
+      }
+    }
+    else
+    {
+      if ((1 << (mfmt + 1)) & mantissa)
+      {
+        mantissa >>= 1;
+        f8_exponent++;
+      }
+    }
+
+    mantissa >>= (mfmt - wm);
+
+    // above range: quantize to maximum possible float of the same sign
+    const int max_exp = (1 << we) - (negative_zero_nan ? 1 : 2);
+    if (f8_exponent > max_exp)
+    {
+      if (clip)
+      {
+        mantissa = (1 << wm) - 1;
+        f8_exponent = max_exp;
+      }
+      else
+      {
+        return signed_inf;
+      }
+    }
+
+    if (f8_exponent == 0 && mantissa == 0)
+    {
+      return negative_zero_nan ? 0 : (sign << 7);
+    }
+    mantissa &= (1 << wm) - 1;
+    return (sign << 7) | (f8_exponent << wm) | mantissa;
+  }
+
 template <typename T>
 DEVICE_IF_HIPCC __forceinline__ T loadnt(T* addr)
 {
@@ -137,6 +346,24 @@ DEVICE_IF_HIPCC __forceinline__ _B16x4 from_floatx4_rtz(const floatx4& inp)
     {
         static_assert(false, "unsupported 16b dtype");
     }
+}
+
+__device__ __forceinline__ floatx4 to_float_fp8x4(const _B8x4& inp)
+{
+#if defined(__gfx90a__)
+    float4 f32x4 =
+        vllm::fp8::vec_conversion<float4, uint32_t>(*reinterpret_cast<const uint32_t*>(&inp));
+    return *reinterpret_cast<floatx4*>(&f32x4);
+#else // MI3xx+ optimized builtins
+    const auto f0 = __builtin_amdgcn_cvt_pk_f32_fp8(inp, false);
+    const auto f1 = __builtin_amdgcn_cvt_pk_f32_fp8(inp, true);
+    floatx4 ret;
+    ret[0] = f0[0];
+    ret[1] = f0[1];
+    ret[2] = f1[0];
+    ret[3] = f1[1];
+    return ret;
+#endif
 }
 
 template <typename T>
@@ -1087,7 +1314,12 @@ DEVICE_IF_HIPCC void k(
     OUTT* out_ptr = out + seq_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
     if constexpr(std::is_same<OUTT, bit8_t>::value)
     {
-        out_ptr[threadIdx.x] = hip_fp8(acc).data;
+        out_ptr[threadIdx.x] = to_float8<
+            4, /* exp bits */  
+            3, /* mantissa bits */  
+            float, /* from_type */  
+            true, /*negative_zero_nan*/
+            true /*clip*/>(acc);
     }
     else
     {
@@ -1103,7 +1335,6 @@ suffix_template_dict = {
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
-#include "hip_float8.h"
 
 #ifdef __HIPCC__
 #define HOST_IF_HIPCC __host__

--- a/flashinfer/jit/aiter_decode_templ.py
+++ b/flashinfer/jit/aiter_decode_templ.py
@@ -1386,8 +1386,7 @@ template<typename... Callables>
 HOST_IF_HIPCC
 void
 schedule_callables_on_gpu(hipStream_t stream, Callables... cs) {
-    bool success = (cs(stream) && ...);
-    if (!success) {
+    if (!(cs(stream) && ...)) {
         HIP_CHECK(hipGetLastError());
     }
 }

--- a/flashinfer/jit/aiter_decode_templ.py
+++ b/flashinfer/jit/aiter_decode_templ.py
@@ -23,40 +23,1003 @@ _FUNC_ARGS = r"""
     torch::Tensor& k_scale,
     torch::Tensor& v_scale,
     const c10::optional<torch::Tensor>& fp8_out_scale,
-    int64_t partition_size
+    int64_t partition_size,
+    int64_t stream
+"""
+
+_PAGED_ATTN_SRC = r"""
+///////////////////////////////////////
+// grid (num_seqs, num_partitions,num_kv_heads)
+// block (256)
+template <typename scalar_t,
+          typename cache_t,
+          vllm::Fp8KVCacheDataType KV_DTYPE,
+          typename OUTT,
+          int BLOCK_SIZE,
+          int HEAD_SIZE,
+          int NUM_THREADS,
+          bool ALIBI_ENABLED,
+          bool LOGITS_SOFT_CAP_ENABLED,
+          int GQA_RATIO>
+__global__ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
+    const scalar_t* __restrict__ q,      // [num_seqs, num_heads, head_size]
+    const cache_t* __restrict__ k_cache, // [num_blocks, num_kv_heads,
+                                         // head_size/x, block_size, x]
+    const cache_t* __restrict__ v_cache, // [num_blocks, num_kv_heads,
+                                         // head_size, block_size]
+    const float scale,
+    const int* __restrict__ kv_indptr,         // [num_seqs + 1]
+    const int* __restrict__ kv_page_indices,   // [max_num_blocks]
+    const int* __restrict__ kv_last_page_lens, // [num_seqs]
+    const float* __restrict__ alibi_slopes,    // [num_heads]
+    const int q_stride,
+    const int kv_block_stride,
+    const int kv_head_stride,
+    const int kv_seq_stride,
+    float* __restrict__ exp_sums,   // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits, // [num_seqs, num_heads,
+                                    // max_num_partitions]
+    scalar_t* __restrict__ out,     // [num_seqs, num_heads, max_num_partitions,
+                                    // head_size]
+    OUTT* __restrict__ final_out,   // [num_seqs, num_heads, head_size]
+    float logits_soft_cap,
+    const float* k_scale_ptr,
+    const float* v_scale_ptr,
+    const float* __restrict__ fp8_out_scale_ptr)
+{
+    constexpr int NWARPS = NUM_THREADS / WARP_SIZE;
+    const int warpid     = threadIdx.x / WARP_SIZE;
+    const int laneid     = threadIdx.x % WARP_SIZE;
+    const int lane4id    = laneid % 4;
+    const int lane16id   = laneid % 16;
+    const int rowid      = laneid / 16;
+
+    const int seq_idx       = blockIdx.x;
+    const int partition_idx = blockIdx.y;
+
+    constexpr int T_PAR_SIZE = 256; // token partition size set to 256
+
+    const int max_num_partitions = gridDim.y;
+    int context_len;
+    if constexpr(BLOCK_SIZE > 1){
+        context_len =
+            (kv_indptr[seq_idx + 1] - kv_indptr[seq_idx] - 1) * BLOCK_SIZE + kv_last_page_lens[seq_idx];
+    }else{
+        context_len = kv_indptr[seq_idx + 1] - kv_indptr[seq_idx];
+    }
+
+    const int partition_start_token_idx = partition_idx * T_PAR_SIZE; // partition_size;
+    // exit if partition is out of context for seq
+    if(partition_start_token_idx >= context_len)
+    {
+        return;
+    }
+
+    constexpr int GQA_RATIO4 = DIVIDE_ROUND_UP(GQA_RATIO, 4);
+
+    __shared__ float shared_qk_max[NWARPS][16 + 1];
+    __shared__ float shared_exp_sum[NWARPS][16 + 1];
+    // shared_logits is used for multiple purposes
+    __shared__ _B16x4 shared_logits[NWARPS][4][16][4];
+
+    // for QK mfma16x16, layout is QHead/Tokenx16 across every 16 lanes, 16 Bytes
+    // HeadElements in each lane, 4x16B HeadElements across 4 rows of warp
+    constexpr int ROWS_PER_WARP = WARP_SIZE / 16; // rows refers to 16 lanes; refer dpp terminology
+    constexpr int CONTIGUOUS_KV_ELEMS_16B_LOAD =
+        16 / sizeof(cache_t); // 8 for 16 bit cache type, 16 for 8 bit types
+    constexpr int QKHE_PER_FETCH =
+        CONTIGUOUS_KV_ELEMS_16B_LOAD *
+        ROWS_PER_WARP; // each fetch across a warp fetches these many elements
+    constexpr int QK_SIZE_RATIO =
+        sizeof(scalar_t) / sizeof(cache_t);              // 1 for 16bit types, 2 for 8bit types
+    constexpr int QKHELOOP = HEAD_SIZE / QKHE_PER_FETCH; // 4xQKHE_16B across warp
+
+    _B16x8 Qlocal[QKHELOOP][QK_SIZE_RATIO]; // note that 16 contiguous elements of Q should
+                                            // be fetched per lane for 8 bit cache types :
+                                            // QK_SIZE_RATIO changes for this
+
+    constexpr int CONTIGUOUS_SCALAR_ELEMS_16B = 16 / sizeof(scalar_t);
+
+    constexpr int TOKENS_PER_WARP =
+        T_PAR_SIZE / NWARPS; // sub partition of tokens per warp for qk calculation
+    constexpr int TLOOP = TOKENS_PER_WARP / 16; // each mfma16x16x16 instruction processes 16 tokens
+
+    _B16x8 Klocal[TLOOP][QKHELOOP]; // can be interpreted as B8x16 for 8 bit types
+
+    const int wg_start_head_idx    = blockIdx.z * GQA_RATIO;
+    const int wg_start_kv_head_idx = blockIdx.z;
+    const int total_num_heads      = gridDim.z * GQA_RATIO;
+
+    // for QK mfma, tokens in multiples of TOKENS_PER_WARP are spread across warps
+    // each mfma takes QH16xT16x16HE across warp
+    // repeat mfmas across QKHELOOP dimension
+    // output layout from QKmfma : QH16xT4x4 16 qheads across 16 lanes, 16 tokens
+    // across 4 rows x 4 tokens per lane
+
+    const int num_context_blocks = DIVIDE_ROUND_UP(context_len, BLOCK_SIZE);
+    const int last_ctx_block     = num_context_blocks - 1;
+
+    const int* block_table_seq = kv_page_indices + kv_indptr[seq_idx];
+
+    int kphysical_block_number[TLOOP];
+
+    // fetch k physical block numbers
+    for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+    {
+        const int klocal_token_idx  = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+        const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
+        const int kblock_idx =
+            (kglobal_token_idx < context_len) ? kglobal_token_idx / BLOCK_SIZE : last_ctx_block;
+        kphysical_block_number[token_depth] = block_table_seq[kblock_idx];
+    }
+
+    // fetch Q in shared across warps and then write to registers
+    const int local_qhead_idx  = 4 * warpid + rowid;
+    const int global_qhead_idx = wg_start_head_idx + local_qhead_idx;
+    const int64_t seq_idx64    = static_cast<int64_t>(seq_idx);
+    const scalar_t* q_ptr      = q + seq_idx64 * q_stride + global_qhead_idx * HEAD_SIZE;
+
+    const int qhead_element = lane16id * CONTIGUOUS_SCALAR_ELEMS_16B;
+    if((local_qhead_idx < GQA_RATIO) && (qhead_element < HEAD_SIZE))
+    {
+        const scalar_t* q_fetch_ptr   = q_ptr + qhead_element;
+        const _B16x8* q_fetch_ptr_16B = reinterpret_cast<const _B16x8*>(q_fetch_ptr);
+        _B16x8 tmp                    = *q_fetch_ptr_16B;
+        if constexpr(KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto)
+        {
+            const int offset1 =
+                lane16id / 4; // 16 contiguous chunks of head elems are spread across 4x4lanes
+            shared_logits[offset1][lane4id][local_qhead_idx][0] = tmp.xy[0];
+            shared_logits[offset1][lane4id][local_qhead_idx][1] = tmp.xy[1];
+        }
+        else
+        {
+            for(int i = 0; i < 2; i++)
+            {
+                const int head_elem = lane16id * 2 + i; // element id in _B16x4 terms
+                const int offset3   = head_elem % 4;
+                const int offset2   = (head_elem / 4) % 4;
+                const int offset1   = head_elem / 4 / 4;
+                shared_logits[offset1][offset2][local_qhead_idx][offset3] = tmp.xy[i];
+            }
+        }
+    }
+    __syncthreads();
+    for(int qkhe_depth = 0; qkhe_depth < QKHELOOP; qkhe_depth++)
+    {
+        for(int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++)
+        {
+            for(int i = 0; i < 2; i++)
+            {
+                Qlocal[qkhe_depth][qkratio].xy[i] =
+                    shared_logits[qkhe_depth][rowid][lane16id % GQA_RATIO][2 * qkratio + i];
+            }
+        }
+    }
+
+    // set to true to enable non temporal kv loads: has some benefit in very high
+    // batch size cases
+    constexpr bool NT_KV_LOAD = false;
+
+    constexpr int KX     = 16 / sizeof(cache_t); // vLLM defines x as 16 Bytes of kv cache elements
+    const cache_t* k_ptr = k_cache + wg_start_kv_head_idx * kv_head_stride;
+
+    const int row_head_elem = rowid * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+    // fetch K values
+    for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+    {
+        const int64_t kblock_number = static_cast<int64_t>(kphysical_block_number[token_depth]);
+        const cache_t* k_ptr2       = k_ptr + kblock_number * kv_block_stride;
+        const int klocal_token_idx  = TOKENS_PER_WARP * warpid + token_depth * 16 + lane16id;
+        const int kglobal_token_idx = partition_start_token_idx + klocal_token_idx;
+        const int kphysical_block_offset = klocal_token_idx % BLOCK_SIZE;
+        const cache_t* k_ptr3            = k_ptr2 + kphysical_block_offset * kv_seq_stride;
+
+        for(int qkhe_depth = 0; qkhe_depth < QKHELOOP; qkhe_depth++)
+        {
+            const int head_elem           = row_head_elem + qkhe_depth * QKHE_PER_FETCH;
+            const int offset1             = head_elem / KX;
+            const int offset2             = head_elem % KX;
+            const cache_t* k_fetch_ptr    = k_ptr3 + offset1 * KX + offset2;
+            const _B16x8* k_fetch_ptr_16B = reinterpret_cast<const _B16x8*>(k_fetch_ptr);
+            if constexpr(NT_KV_LOAD)
+            {
+                Klocal[token_depth][qkhe_depth] = load_ntmprl_16Byte(k_fetch_ptr_16B);
+            }
+            else
+            {
+                Klocal[token_depth][qkhe_depth] = *k_fetch_ptr_16B;
+            }
+        }
+    }
+
+    float alibi_slope;
+    if constexpr(ALIBI_ENABLED)
+    {
+        const int alibi_head_idx = wg_start_head_idx + lane16id;
+        alibi_slope              = (lane16id < GQA_RATIO) ? alibi_slopes[alibi_head_idx] : 0.f;
+    }
+
+    constexpr int n_thread_per_warp  = (NWARPS * 16) / CONTIGUOUS_KV_ELEMS_16B_LOAD; // 8
+    constexpr int k_thread_per_warp  = WARP_SIZE / n_thread_per_warp;                // 8
+    constexpr int n_thread_per_block = n_thread_per_warp;                            // 8
+    constexpr int k_thread_per_block = NWARPS * k_thread_per_warp;                   // 32
+    constexpr int k_repeat           = TOKENS_PER_WARP / k_thread_per_block;         // 2
+    static_assert(BLOCK_SIZE <= k_thread_per_block);
+
+    constexpr int VTOKENS_PER_LANE =
+        TOKENS_PER_WARP / ROWS_PER_WARP;       // 64/4 = 16 contiguous vtokens per lane
+    constexpr int VBLOCKS_PER_LANE = k_repeat; // assumes block size <= 32
+    constexpr int VTLOOP           = NWARPS;   // corresponds to tokens across warps
+    constexpr int VTLANELOOP =
+        DIVIDE_ROUND_UP(VTOKENS_PER_LANE,
+                        CONTIGUOUS_KV_ELEMS_16B_LOAD); // optimized for 16B fetches; assumes
+                                                       // minimum block size is 16
+    constexpr int VHELOOP = HEAD_SIZE / 16 / NWARPS;   // head_size distributed across warps; each
+                                                       // mfma instr works on 16 head elements
+
+    int vphysical_block_number[VTLOOP][VBLOCKS_PER_LANE];
+
+#define DEBUG_PRINT 0
+#define THREAD_IDX 255
+#define BLOCK_IDX 0
+
+#if DEBUG_PRINT
+#define DEBUG_STMTS(stmts)                                   \
+    if(threadIdx.x == THREAD_IDX && blockIdx.y == BLOCK_IDX) \
+    {                                                        \
+        stmts                                                \
+    }
+#else
+#define DEBUG_STMTS(stmts)
+#endif
+
+    // fetch v physical block numbers
+    for(int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++)
+    {
+        for(int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE; vblock_depth++)
+        {
+            const int vlocal_token_idx = vtoken_depth * TOKENS_PER_WARP +
+                                         vblock_depth * k_thread_per_block +
+                                         threadIdx.x / n_thread_per_block;
+            const int vglobal_token_idx = partition_start_token_idx + vlocal_token_idx;
+            const int vblock_idx =
+                (vglobal_token_idx < context_len) ? vglobal_token_idx / BLOCK_SIZE : last_ctx_block;
+            vphysical_block_number[vtoken_depth][vblock_depth] = block_table_seq[vblock_idx];
+
+            DEBUG_STMTS(printf("[POYENC] id: (%3d, %3d), loop: (%d, %d), vlocal_token_idx: %3d, "
+                               "vglobal_token_idx: %3d, vblock_idx: %2d\n",
+                               BLOCK_IDX,
+                               THREAD_IDX,
+                               vtoken_depth,
+                               vblock_depth,
+                               vlocal_token_idx,
+                               vglobal_token_idx,
+                               vblock_idx);)
+        }
+    }
+
+    _B16x8 Vlocal[VTLOOP][VHELOOP][VTLANELOOP]; // this can be interpreted as B8x16 too
+    __shared__ unsigned char vlds_ptr[TOKENS_PER_WARP * n_thread_per_block * 16];
+    static_assert(VBLOCKS_PER_LANE == VTLANELOOP,
+                  "make sure we can keep un-shuffled data in Vlocal as well");
+
+    const cache_t* v_ptr = v_cache + wg_start_kv_head_idx * kv_head_stride +
+                           ((threadIdx.x / n_thread_per_block) % BLOCK_SIZE) * kv_seq_stride;
+
+    // v fetches are 16head elems across lanes x 16 tokens per lane
+    for(int vhe_depth = 0; vhe_depth < VHELOOP; vhe_depth++)
+    {
+        for(int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++)
+        {
+            for(int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE; vblock_depth++)
+            {
+                const int vlds_col_idx = laneid % n_thread_per_block;
+                const int vhead_elem =
+                    vhe_depth * NWARPS * 16 + vlds_col_idx * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+                const cache_t* v_ptr2 = v_ptr + vhead_elem;
+
+                const int64_t vblock_number =
+                    static_cast<int64_t>(vphysical_block_number[vtoken_depth][vblock_depth]);
+                const cache_t* v_fetch_ptr = v_ptr2 + (vblock_number * kv_block_stride);
+
+                Vlocal[vtoken_depth][vhe_depth][vblock_depth] =
+                    *reinterpret_cast<const _B16x8*>(v_fetch_ptr);
+            }
+        }
+    }
+
+    // calculate post qk mfma scale
+    float scale2 = scale;
+    if constexpr(KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto)
+    {
+        // multiply by k_scale if fp8 kv cache
+        scale2 *= *k_scale_ptr;
+    }
+
+    floatx4 dout[TLOOP];
+    // qk mfma
+    for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+    {
+        dout[token_depth] = {0};
+        for(int qkhe_depth = 0; qkhe_depth < QKHELOOP; qkhe_depth++)
+        {
+            if constexpr(KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto)
+            {
+                for(int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++)
+                {
+                    for(int i = 0; i < 2; i++)
+                    {
+                        dout[token_depth] = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                            Klocal[token_depth][qkhe_depth].xy[i],
+                            Qlocal[qkhe_depth][qkratio].xy[i],
+                            dout[token_depth]);
+                    }
+                }
+            }
+            else
+            { // kv cache dtype fp8
+                auto Ktmp       = Klocal[token_depth][qkhe_depth];
+                _B8x16 Ktmp8x16 = *reinterpret_cast<_B8x16*>(&Ktmp);
+                for(int qkratio = 0; qkratio < QK_SIZE_RATIO; qkratio++)
+                {
+                    _B8x8 Ktmp8x8    = Ktmp8x16.xy[qkratio];
+                    _B16x8 Klocaltmp = convert_b8x8_custom<scalar_t>(Ktmp8x8);
+                    for(int i = 0; i < 2; i++)
+                    {
+                        dout[token_depth] = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                            Klocaltmp.xy[i], Qlocal[qkhe_depth][qkratio].xy[i], dout[token_depth]);
+                    }
+                }
+            }
+        }
+        dout[token_depth] *= scale2;
+    }
+
+    const int qkout_token_idx = partition_start_token_idx + TOKENS_PER_WARP * warpid + rowid * 4;
+
+    // apply alibi
+    if constexpr(ALIBI_ENABLED)
+    {
+        for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+        {
+            const int local_token_idx = qkout_token_idx + token_depth * 16;
+            const int alibi_offset    = local_token_idx - context_len + 1;
+            for(int i = 0; i < 4; i++)
+            {
+                dout[token_depth][i] += alibi_slope * (alibi_offset + i);
+            }
+        }
+    }
+    // apply soft-capping to logits
+    if constexpr(LOGITS_SOFT_CAP_ENABLED)
+    {
+        const float logits_soft_cap_reciprocal = __frcp_rn(logits_soft_cap);
+        const auto apply_soft_cap              = [&](float value) {
+            return logits_soft_cap * tanhf(value * logits_soft_cap_reciprocal);
+        };
+
+        for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+        {
+            for(int i = 0; i < 4; i++)
+            {
+                dout[token_depth][i] = apply_soft_cap(dout[token_depth][i]);
+            }
+        }
+    }
+
+    // calculate qk_max and exp_sum per warp and write to shared memory
+    float qk_max  = -FLT_MAX;
+    float exp_sum = 0.0f;
+
+    for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+    {
+        const int local_token_idx = qkout_token_idx + token_depth * 16;
+        for(int i = 0; i < 4; i++)
+        {
+            const float tmp = (local_token_idx + i < context_len) ? dout[token_depth][i] : -FLT_MAX;
+            qk_max          = fmaxf(qk_max, tmp);
+        }
+    }
+
+    for(int mask = WARP_SIZE / 2; mask >= 16; mask /= 2)
+    {
+        qk_max = fmaxf(qk_max, __shfl_xor(qk_max, mask));
+    }
+
+    for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+    {
+        const int local_token_idx = qkout_token_idx + token_depth * 16;
+        for(int i = 0; i < 4; i++)
+        {
+            const float tmp =
+                (local_token_idx + i < context_len) ? __expf(dout[token_depth][i] - qk_max) : 0.0f;
+            dout[token_depth][i] = tmp;
+            exp_sum += tmp;
+        }
+    }
+
+    for(int mask = WARP_SIZE / 2; mask >= 16; mask /= 2)
+    {
+        exp_sum += __shfl_xor(exp_sum, mask);
+    }
+
+    __syncthreads(); // sync before writing to shared mem
+
+    float* shared_mem = reinterpret_cast<float*>(shared_logits);
+    if(laneid < 16)
+    {
+        const int qk_max_offset    = warpid * 16 + lane16id;
+        shared_mem[qk_max_offset]  = qk_max;
+        const int exp_sum_offset   = NWARPS * 16 + qk_max_offset;
+        shared_mem[exp_sum_offset] = exp_sum;
+    }
+
+    __syncthreads();
+
+    // calculate partition qk_max and exp_sum
+    float partition_qk_max = -FLT_MAX;
+    float warp_qk_max_exp[NWARPS];
+    float partition_exp_sum = 0.0f;
+
+    for(int w = 0; w < NWARPS; w++)
+    {
+        warp_qk_max_exp[w] = shared_mem[w * 16 + lane16id];
+        partition_qk_max   = fmaxf(partition_qk_max, warp_qk_max_exp[w]);
+    }
+
+    for(int w = 0; w < NWARPS; w++)
+    {
+        warp_qk_max_exp[w] = __expf(warp_qk_max_exp[w] - partition_qk_max);
+        partition_exp_sum += shared_mem[NWARPS * 16 + w * 16 + lane16id] * warp_qk_max_exp[w];
+    }
+
+    const float inv_sum_scale =
+        __fdividef(1.f, partition_exp_sum + 1e-6f) * warp_qk_max_exp[warpid];
+
+    __syncthreads();
+
+    // write logits to shared mem
+    for(int token_depth = 0; token_depth < TLOOP; token_depth++)
+    {
+        dout[token_depth] *= inv_sum_scale;
+        // use rtz conversion for performance, with no visible impact on accuracy
+        shared_logits[warpid][token_depth][lane16id][rowid] =
+            from_floatx4_rtz<scalar_t>(dout[token_depth]);
+    }
+    // write out partition max_logits and exp_sum
+    if(threadIdx.x < GQA_RATIO)
+    {
+        const int qhead_idx = lane16id;
+        const int offset    = seq_idx * total_num_heads * max_num_partitions +
+                           (wg_start_head_idx + qhead_idx) * max_num_partitions + partition_idx;
+        max_logits[offset] = partition_qk_max;
+        exp_sums[offset]   = partition_exp_sum;
+    }
+
+    __syncthreads();
+
+    constexpr int ELEMS8_ELEMS4_RATIO  = 8 / 4;
+    constexpr int ELEMS16_ELEMS8_RATIO = 16 / 8;
+
+    _B16x4 outelems[VHELOOP];
+    // Softmax V mfma
+    // v layout: 16he across lanes x 16 tokens per lane
+    for(int vhe_depth = 0; vhe_depth < VHELOOP; vhe_depth++)
+    {
+        floatx4 tmp_out = {0};
+
+        for(int vtoken_depth = 0; vtoken_depth < VTLOOP; vtoken_depth++)
+        {
+            // 1. store data into LDS
+            for(int vblock_depth = 0; vblock_depth < VBLOCKS_PER_LANE; vblock_depth++)
+            {
+                const int vlds_col_idx = laneid % n_thread_per_block;
+                const int vlocal_token_idx =
+                    vblock_depth * k_thread_per_block + threadIdx.x / n_thread_per_block;
+                *reinterpret_cast<_B16x8*>(vlds_ptr +
+                                           (/*row=*/vlocal_token_idx * n_thread_per_block +
+                                            /*col=*/vlds_col_idx) *
+                                               16) = Vlocal[vtoken_depth][vhe_depth][vblock_depth];
+            }
+            __syncthreads();
+
+            // 2. load data from LDS (transposed), then do multification
+            if constexpr(KV_DTYPE == vllm::Fp8KVCacheDataType::kAuto)
+            {
+                for(int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++)
+                {
+                    {
+                        const int vlocal_head_elem = warpid * 16 + lane16id;
+
+                        const int vlds_col_idx  = vlocal_head_elem / CONTIGUOUS_KV_ELEMS_16B_LOAD;
+                        const int vlds_elem_idx = vlocal_head_elem % CONTIGUOUS_KV_ELEMS_16B_LOAD;
+
+                        const int vlocal_token_idx =
+                            rowid * VTOKENS_PER_LANE + vfetch_depth * CONTIGUOUS_KV_ELEMS_16B_LOAD;
+
+                        // read data points individually and save them into array
+                        cache_t elems[CONTIGUOUS_KV_ELEMS_16B_LOAD];
+                        for(int d2 = 0; d2 < CONTIGUOUS_KV_ELEMS_16B_LOAD; ++d2)
+                        {
+                            const cache_t* fetched_elems = reinterpret_cast<const cache_t*>(
+                                vlds_ptr + (/*row=*/(vlocal_token_idx + d2) * n_thread_per_block +
+                                            /*col=*/vlds_col_idx) *
+                                               16);
+
+                            elems[d2] = fetched_elems[vlds_elem_idx];
+                        }
+
+                        // copy all the read data points together
+                        Vlocal[vtoken_depth][vhe_depth][vfetch_depth] =
+                            *reinterpret_cast<const _B16x8*>(elems);
+                    }
+
+                    for(int i = 0; i < ELEMS8_ELEMS4_RATIO; i++)
+                    {
+                        const int offset = rowid * VTLANELOOP * ELEMS8_ELEMS4_RATIO +
+                                           vfetch_depth * ELEMS8_ELEMS4_RATIO + i;
+                        const int offset1 = offset % ROWS_PER_WARP;
+                        const int offset2 = offset / ROWS_PER_WARP;
+                        // output format is 16 qheads across 16 lanes, 16 head elems spread
+                        // across 4 rows
+                        tmp_out = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                            Vlocal[vtoken_depth][vhe_depth][vfetch_depth].xy[i],
+                            shared_logits[vtoken_depth][offset2][lane16id][offset1],
+                            tmp_out);
+                    }
+                }
+                // KV cache fp8
+            }
+            else
+            {
+                for(int vfetch_depth = 0; vfetch_depth < VTLANELOOP; vfetch_depth++)
+                {
+                    _B16x8 Vtmp = Vlocal[vtoken_depth][vhe_depth][vfetch_depth];
+                    // reinterpret V format as 16 elements of 8bits
+                    _B8x16 Vtmp8x16 = *reinterpret_cast<_B8x16*>(&Vtmp);
+                    for(int j = 0; j < ELEMS16_ELEMS8_RATIO; j++)
+                    {
+                        _B8x8 Vtmp8x8    = Vtmp8x16.xy[j];
+                        _B16x8 Vlocaltmp = convert_b8x8_custom<scalar_t>(Vtmp8x8);
+                        for(int i = 0; i < ELEMS8_ELEMS4_RATIO; i++)
+                        {
+                            const int offset = rowid * ELEMS16_ELEMS8_RATIO * ELEMS8_ELEMS4_RATIO +
+                                               j * ELEMS8_ELEMS4_RATIO + i;
+                            const int offset1 = offset % ROWS_PER_WARP;
+                            const int offset2 = offset / ROWS_PER_WARP;
+                            // output format is 16 qheads across 16 lanes, 16 head elems
+                            // spread across 4 rows
+                            tmp_out = gcn_mfma16x16x16_instr<scalar_t, 0, 0, 0>(
+                                Vlocaltmp.xy[i],
+                                shared_logits[vtoken_depth][offset2][lane16id][offset1],
+                                tmp_out);
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+        // apply post Softmax V mfma v_scale
+        if constexpr(KV_DTYPE != vllm::Fp8KVCacheDataType::kAuto)
+        {
+            tmp_out *= *v_scale_ptr;
+        }
+        outelems[vhe_depth] = from_floatx4<scalar_t>(tmp_out);
+    }
+
+    __syncthreads();
+
+    // store Softmax-V mfma output to shared mem
+    for(int vhe_depth = 0; vhe_depth < VHELOOP; vhe_depth++)
+    {
+        // lane16 id head dimension; rowid head element dimension
+        shared_logits[warpid][vhe_depth][lane16id][rowid] = outelems[vhe_depth];
+    }
+
+    __syncthreads();
+
+    // write to tmp_out with coalesced writes after reading from shared mem
+    if(warpid == 0)
+    {
+        _B16x8 vout[GQA_RATIO4];
+        // each lane writes out 16Bytes of tmp_out along head elem dimension
+        const int head_elem_idx = lane16id * 8;
+        if(head_elem_idx < HEAD_SIZE)
+        {
+            for(int h = 0; h < GQA_RATIO4; h++)
+            {
+                const int local_head_idx = 4 * h + rowid;
+                const int offset1        = (head_elem_idx / 16) % 4;
+                const int offset2        = head_elem_idx / 16 / NWARPS;
+                const int offset3        = (head_elem_idx / 4) % 4;
+                for(int i = 0; i < 2; i++)
+                {
+                    vout[h].xy[i] = shared_logits[offset1][offset2][local_head_idx][offset3 + i];
+                }
+            }
+
+            const int hsz_maxp_mult = HEAD_SIZE * max_num_partitions;
+            scalar_t* out_ptr =
+                out + seq_idx * total_num_heads * hsz_maxp_mult + partition_idx * HEAD_SIZE;
+            for(int h = 0; h < GQA_RATIO4; h++)
+            {
+                const int local_head_idx = 4 * h + rowid;
+                if(local_head_idx < GQA_RATIO)
+                {
+                    const int out_head_idx = wg_start_head_idx + local_head_idx;
+                    scalar_t* out_ptr2     = out_ptr + out_head_idx * hsz_maxp_mult;
+                    scalar_t* out_ptr3     = out_ptr2 + head_elem_idx;
+                    _B16x8* out_ptr_B16x8  = reinterpret_cast<_B16x8*>(out_ptr3);
+                    *out_ptr_B16x8         = vout[h];
+                }
+            }
+        }
+    }
+}
+"""
+
+_REDUCE_SRC = r"""
+// Grid: (num_heads, num_seqs).
+template <typename scalar_t,
+          typename OUTT,
+          int HEAD_SIZE,
+          int NUM_THREADS,
+          int PARTITION_SIZE,
+          int NPAR_LOOPS, bool ENABLE_LAST_PAGE_LENS>
+__global__ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_reduce_kernel(
+    OUTT* __restrict__ out,                    // [num_seqs, num_heads, head_size]
+    const float* __restrict__ exp_sums,        // [num_seqs, num_heads,
+                                               // max_num_partitions]
+    const float* __restrict__ max_logits,      // [num_seqs, num_heads,
+                                               // max_num_partitions]
+    const scalar_t* __restrict__ tmp_out,      // [num_seqs, num_heads,
+                                               // max_num_partitions, head_size]
+    const int* __restrict__ kv_indptr,         // [num_seqs + 1]
+    const int* __restrict__ kv_last_page_lens, // [num_seqs]
+    const int block_size,
+    const int max_num_partitions,
+    const float* __restrict__ fp8_out_scale_ptr)
+{
+    const int num_heads = gridDim.x;
+    const int head_idx  = blockIdx.x;
+    const int seq_idx   = blockIdx.y;
+    int context_len;
+    if constexpr(ENABLE_LAST_PAGE_LENS){
+        context_len =
+            (kv_indptr[seq_idx + 1] - kv_indptr[seq_idx] - 1) * block_size + kv_last_page_lens[seq_idx];
+    }else{
+        context_len = kv_indptr[seq_idx + 1] - kv_indptr[seq_idx];
+    }
+    const int num_partitions = DIVIDE_ROUND_UP(context_len, PARTITION_SIZE);
+    constexpr int NUM_WARPS  = NUM_THREADS / WARP_SIZE;
+    const int warpid         = threadIdx.x / WARP_SIZE;
+    const int laneid         = threadIdx.x % WARP_SIZE;
+
+    __shared__ float shared_global_exp_sum;
+    // max num partitions supported is warp_size * NPAR_LOOPS
+    __shared__ float shared_exp_sums[NPAR_LOOPS * WARP_SIZE];
+
+    if(warpid == 0)
+    {
+        const float* max_logits_ptr =
+            max_logits + seq_idx * num_heads * max_num_partitions + head_idx * max_num_partitions;
+
+        // valid partition is the last valid partition in case threadid > num
+        // partitions
+        int valid_partition[NPAR_LOOPS];
+        float reg_max_logit[NPAR_LOOPS];
+        const int last_valid_partition = num_partitions - 1;
+
+#pragma unroll
+        for(int i = 0; i < NPAR_LOOPS; i++)
+        {
+            const int partition_no = i * WARP_SIZE + threadIdx.x;
+            valid_partition[i] =
+                (partition_no < num_partitions) ? partition_no : last_valid_partition;
+        }
+#pragma unroll
+        for(int i = 0; i < NPAR_LOOPS; i++)
+        {
+            reg_max_logit[i] = max_logits_ptr[valid_partition[i]];
+        }
+        float max_logit = reg_max_logit[0];
+#pragma unroll
+        for(int i = 1; i < NPAR_LOOPS; i++)
+        {
+            max_logit = fmaxf(max_logit, reg_max_logit[i]);
+        }
+
+#pragma unroll
+        for(int mask = WARP_SIZE / 2; mask >= 1; mask /= 2)
+        {
+            max_logit = fmaxf(max_logit, __shfl_xor(max_logit, mask));
+        }
+
+        const float* exp_sums_ptr =
+            exp_sums + seq_idx * num_heads * max_num_partitions + head_idx * max_num_partitions;
+
+        float rescaled_exp_sum[NPAR_LOOPS];
+#pragma unroll
+        for(int i = 0; i < NPAR_LOOPS; i++)
+        {
+            rescaled_exp_sum[i] = exp_sums_ptr[valid_partition[i]];
+        }
+#pragma unroll
+        for(int i = 0; i < NPAR_LOOPS; i++)
+        {
+            const int partition_no = i * WARP_SIZE + threadIdx.x;
+            rescaled_exp_sum[i] *=
+                (partition_no < num_partitions) ? expf(reg_max_logit[i] - max_logit) : 0.0f;
+        }
+        float global_exp_sum = rescaled_exp_sum[0];
+#pragma unroll
+        for(int i = 1; i < NPAR_LOOPS; i++)
+        {
+            global_exp_sum += rescaled_exp_sum[i];
+        }
+#pragma unroll
+        for(int i = 0; i < NPAR_LOOPS; i++)
+        {
+            const int partition_no        = i * WARP_SIZE + threadIdx.x;
+            shared_exp_sums[partition_no] = rescaled_exp_sum[i];
+        }
+
+#pragma unroll
+        for(int mask = WARP_SIZE / 2; mask >= 1; mask /= 2)
+        {
+            global_exp_sum += __shfl_xor(global_exp_sum, mask);
+        }
+        if(threadIdx.x == 0)
+        {
+            shared_global_exp_sum = global_exp_sum;
+        }
+    } // warpid == 0
+    const scalar_t* tmp_out_ptr = tmp_out + seq_idx * num_heads * max_num_partitions * HEAD_SIZE +
+                                  head_idx * max_num_partitions * HEAD_SIZE + threadIdx.x;
+    constexpr int MAX_NPAR = 64;
+    scalar_t tmps[MAX_NPAR];
+    const float dzero = 0.0f;
+#pragma unroll
+    for(int j = 0; j < MAX_NPAR; j++)
+    {
+        tmps[j] = from_float<scalar_t>(dzero);
+    }
+    const int last_partition_offset = (num_partitions - 1) * HEAD_SIZE;
+    const int num_partition_offset  = (num_partitions)*HEAD_SIZE;
+    int idx                         = 0;
+
+    constexpr int JCHUNK = 16;
+
+#pragma unroll
+    for(int j = 0; j < JCHUNK * HEAD_SIZE; j += HEAD_SIZE)
+    {
+        // lastj is last valid partition
+        const int lastj_offset = (j < num_partition_offset) ? j : last_partition_offset;
+        tmps[idx]              = tmp_out_ptr[lastj_offset];
+        idx++;
+    }
+    __syncthreads();
+
+    if(num_partitions > JCHUNK)
+    {
+#pragma unroll
+        for(int j = JCHUNK * HEAD_SIZE; j < 2 * JCHUNK * HEAD_SIZE; j += HEAD_SIZE)
+        {
+            const int lastj_offset = (j < num_partition_offset) ? j : last_partition_offset;
+            tmps[idx]              = tmp_out_ptr[lastj_offset];
+            idx++;
+        }
+
+        if(num_partitions > 2 * JCHUNK)
+        {
+#pragma unroll
+            for(int j = 2 * JCHUNK * HEAD_SIZE; j < MAX_NPAR * HEAD_SIZE; j += HEAD_SIZE)
+            {
+                const int lastj_offset = (j < num_partition_offset) ? j : last_partition_offset;
+                tmps[idx]              = tmp_out_ptr[lastj_offset];
+                idx++;
+            }
+        }
+    } // num_partitions > JCHUNK
+
+    // Aggregate tmp_out to out.
+    float acc = 0.0f;
+#pragma unroll
+    for(int j = 0; j < JCHUNK; j++)
+    {
+        acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+    }
+    if(num_partitions > JCHUNK)
+    {
+#pragma unroll
+        for(int j = JCHUNK; j < 2 * JCHUNK; j++)
+        {
+            acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+        }
+        if(num_partitions > 2 * JCHUNK)
+        {
+#pragma unroll
+            for(int j = 2 * JCHUNK; j < MAX_NPAR; j++)
+            {
+                acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j];
+            }
+        }
+    }
+
+    for(int p = 1; p < NPAR_LOOPS; p++)
+    {
+        if(num_partitions > p * MAX_NPAR)
+        {
+            idx = 0;
+#pragma unroll
+            for(int j = p * MAX_NPAR * HEAD_SIZE; j < (p + 1) * MAX_NPAR * HEAD_SIZE;
+                j += HEAD_SIZE)
+            {
+                // lastj is last valid partition
+                const int lastj_offset = (j < num_partition_offset) ? j : last_partition_offset;
+                tmps[idx]              = tmp_out_ptr[lastj_offset];
+                idx++;
+            }
+
+#pragma unroll
+            for(int j = 0; j < MAX_NPAR; j++)
+            {
+                acc += to_float<scalar_t>(tmps[j]) * shared_exp_sums[j + p * MAX_NPAR];
+            }
+        }
+    }
+
+    const float inv_global_exp_sum = __fdividef(1.0f, shared_global_exp_sum + 1e-6f);
+    const float out_scale = (fp8_out_scale_ptr != nullptr) ? 1.0f / (*fp8_out_scale_ptr) : 1.0f;
+    acc *= inv_global_exp_sum;
+    acc *= out_scale;
+    OUTT* out_ptr = out + seq_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
+    if constexpr(std::is_same<OUTT, bit8_t>::value)
+    {
+        out_ptr[threadIdx.x] = hip_fp8(acc).data;
+    }
+    else
+    {
+        out_ptr[threadIdx.x] = from_float<scalar_t>(acc);
+    }
+}
+
+#define LAUNCH_CUSTOM_REDUCTION(NPAR_LOOPS)                                                        \
+    status = paged_attention_ll4mi_reduce_kernel<T, OUTT, HEAD_SIZE, HEAD_SIZE, PARTITION_SIZE, NPAR_LOOPS, (BLOCK_SIZE > 1)> \
+        <<<reduce_grid, reduce_block, 0, stream>>>(out_ptr,                                        \
+                                                   exp_sums_ptr,                                   \
+                                                   max_logits_ptr,                                 \
+                                                   tmp_out_ptr,                                    \
+                                                   kv_indptr_ptr,                                  \
+                                                   kv_last_page_lens_ptr,                          \
+                                                   BLOCK_SIZE,                                     \
+                                                   max_num_partitions,                             \
+                                                   fp8_out_scale_ptr);
+
 """
 
 suffix_template_dict = {
-    '.hip': r"""// generated with aiter_decode_templ.py
+    '.cu': r"""// generated with aiter_decode_templ.py
 #include "pytorch_extension_utils.h"
 
+{{paged_attn_kernel}}
+
+{{reduce_kernel}}
+
 void {{func_name}}({{func_args}}) {
-    paged_attention_custom_launcher<
-        {{query_dtype}},
-        {{key_value_dtype}},
-        {{kvcache_dtype}},
-        {{block_size}},
-        {{head_size}},
-        {{out_dtype}},
-        {{partition_size_old}},
-        {{alibi_enabled}},
-        {{logits_soft_cap_enabled}}>(
-        out,
-        workspace_buffer,
-        query,
-        key_cache,
-        value_cache,
-        scale,
-        kv_indptr,
-        kv_page_indices,
-        kv_last_page_lens,
-        max_num_partitions,
-        alibi_slopes,
-        kv_cache_layout,
-        logits_soft_cap,
-        k_scale,
-        v_scale,
-        fp8_out_scale);
+    using T = {{query_dtype}};
+    using KVT = {{key_value_dtype}};
+    using OUTT = {{out_dtype}};
+
+    constexpr int32_t KV_DTYPE = 0;
+
+    constexpr int32_t HEAD_SIZE = {{head_size}};
+    constexpr int32_t BLOCK_SIZE = {{block_size}};
+
+    constexpr int32_t ALIBI_ENABLED = {{alibi_enabled}};
+    constexpr int32_t LOGITS_SOFT_CAP_ENABLED = {{logits_soft_cap_enabled}};
+    constexpr int32_t GQA_RATIO = {{gqa_ratio}};
+
+    const int num_kv_heads = kv_cache_layout=="HND" ? key_cache.size(1) : key_cache.size(2);
+    int num_seqs        = query.size(0);
+    int num_heads       = query.size(1);
+    int head_size       = query.size(2);
+    int q_stride        = query.stride(0);
+    int kv_block_stride = key_cache.stride(0);
+    int kv_head_stride  = kv_cache_layout == "HND" ? key_cache.stride(1) : key_cache.stride(2);
+    int kv_seq_stride   = kv_cache_layout == "HND" ? key_cache.stride(2) : key_cache.stride(1);
+
+    const float* alibi_slopes_ptr =
+        alibi_slopes ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr()) : nullptr;
+
+    T* query_ptr               = reinterpret_cast<T*>(query.data_ptr());
+    KVT* key_cache_ptr         = reinterpret_cast<KVT*>(key_cache.data_ptr());
+    KVT* value_cache_ptr       = reinterpret_cast<KVT*>(value_cache.data_ptr());
+    int* kv_indptr_ptr         = kv_indptr.data_ptr<int>();
+    int* kv_page_indices_ptr   = kv_page_indices.data_ptr<int>();
+    int* kv_last_page_lens_ptr = BLOCK_SIZE > 1 ? kv_last_page_lens.value().data_ptr<int>() : nullptr;
+
+    const float* k_scale_ptr = reinterpret_cast<const float*>(k_scale.data_ptr());
+    const float* v_scale_ptr = reinterpret_cast<const float*>(v_scale.data_ptr());
+    const float* fp8_out_scale_ptr =
+        fp8_out_scale ? reinterpret_cast<const float*>(fp8_out_scale.value().data_ptr()) : nullptr;
+    OUTT* out_ptr = reinterpret_cast<OUTT*>(out.data_ptr());
+
+    // partition size is fixed at 256 since both mfma4 and mfma16 kernels support it
+    // mfma4 kernel also supports partition size 512
+    constexpr int PARTITION_SIZE = 256;
+    const int gqa_ratio          = num_heads / num_kv_heads;
+    TORCH_CHECK(num_heads % num_kv_heads == 0);
+    TORCH_CHECK(head_size == HEAD_SIZE);
+
+    // split workspace into 3 intermediate tensors
+    float* exp_sums_ptr   = reinterpret_cast<float*>(workspace_buffer.data_ptr());
+    float* max_logits_ptr = exp_sums_ptr + (num_seqs * num_heads * max_num_partitions);
+    T* tmp_out_ptr =
+        reinterpret_cast<T*>(max_logits_ptr + (num_seqs * num_heads * max_num_partitions));
+
+    constexpr int NTHR = 256;
+    dim3 grid(num_seqs, max_num_partitions, num_kv_heads);
+    dim3 block(NTHR);
+    // const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+    const auto stream = reinterpret_cast<gpuStream_t>(cuda_stream);
+
+    auto status = paged_attention_ll4mi_QKV_mfma16_kernel<T,
+                                            KVT,
+                                            KV_DTYPE,
+                                            OUTT,
+                                            BLOCK_SIZE,
+                                            HEAD_SIZE,
+                                            NTHR,
+                                            ALIBI_ENABLED,
+                                            LOGITS_SOFT_CAP_ENABLED,
+                                            GQA_RATIO>
+        <<<grid, block, 0, stream>>>(query_ptr,
+                                     key_cache_ptr,
+                                     value_cache_ptr,
+                                     scale,
+                                     kv_indptr_ptr,
+                                     kv_page_indices_ptr,
+                                     kv_last_page_lens_ptr,
+                                     alibi_slopes_ptr,
+                                     q_stride,
+                                     kv_block_stride,
+                                     kv_head_stride,
+                                     kv_seq_stride,
+                                     exp_sums_ptr,
+                                     max_logits_ptr,
+                                     tmp_out_ptr,
+                                     out_ptr,
+                                     logits_soft_cap,
+                                     k_scale_ptr,
+                                     v_scale_ptr,
+                                     fp8_out_scale_ptr);
+
+    TORCH_CHECK(status == gpuSuccess, "paged_attention_ll4mi_QKV_mfma16_kernel failed with error ",
+        gpuGetErrorString(status));
+
+    dim3 reduce_grid(num_heads, num_seqs);
+    dim3 reduce_block(head_size);
+    const int npar_loops = DIVIDE_ROUND_UP(max_num_partitions, WARP_SIZE);
+
+    // reduction kernel supports upto 8 NPAR_loops * 64 (warp_size) * 256 (partition size) = 128K
+    // context length
+    switch(npar_loops)
+    {
+    case 1: LAUNCH_CUSTOM_REDUCTION(1); break;
+    case 2: LAUNCH_CUSTOM_REDUCTION(2); break;
+    case 3: LAUNCH_CUSTOM_REDUCTION(3); break;
+    case 4: LAUNCH_CUSTOM_REDUCTION(4); break;
+    case 5: LAUNCH_CUSTOM_REDUCTION(5); break;
+    case 6: LAUNCH_CUSTOM_REDUCTION(6); break;
+    case 7: LAUNCH_CUSTOM_REDUCTION(7); break;
+    case 8: LAUNCH_CUSTOM_REDUCTION(8); break;
+    default: TORCH_CHECK(false, "Unsupported npar_loops: ", npar_loops); break;
+    }
+
+    TORCH_CHECK(status == gpuSuccess, "paged_attention_ll4mi_reduce_kernel failed with error ",
+        gpuGetErrorString(status));
 }
 
 """,

--- a/flashinfer/jit/aiter_decode_templ.py
+++ b/flashinfer/jit/aiter_decode_templ.py
@@ -1,0 +1,36 @@
+# TODO: license header
+aiter_decode_templ = {
+    '.hip': r"""// generated with aiter_decode_templ.py
+
+""",
+    '_pybind.cc': r"""// generated with aiter_decode_templ.py
+#include "pytorch_extension_utils.h"
+
+void paged_attention(
+    torch::Tensor& out, // [num_seqs, num_heads, head_size]
+    torch::Tensor& workspace_buffer,
+    torch::Tensor& query,       // [num_seqs, num_heads, head_size]
+    torch::Tensor& key_cache,   // [num_blocks, num_heads, block_size, head_size] or
+                                // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor& value_cache, // [num_blocks, num_heads, block_size, head_size] or
+                                // [num_blocks, block_size, num_heads, head_size]
+    double scale,
+    torch::Tensor& kv_indptr,         // [num_seqs + 1]
+    torch::Tensor& kv_page_indices,   // [max_num_blocks]
+    std::optional<torch::Tensor>& kv_last_page_lens, // [num_seqs]
+    int64_t block_size,
+    int64_t max_num_partitions,
+    const std::optional<torch::Tensor>& alibi_slopes,
+    const std::string& kv_cache_dtype,
+    const std::string& kv_cache_layout,
+    float logits_soft_cap,
+    torch::Tensor& k_scale,
+    torch::Tensor& v_scale,
+    const c10::optional<torch::Tensor>& fp8_out_scale,
+    int64_t partition_size);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("run", &paged_attention,
+        "AITER paged attention");
+""",
+}

--- a/flashinfer/jit/aiter_decode_templ.py
+++ b/flashinfer/jit/aiter_decode_templ.py
@@ -1,12 +1,64 @@
 # TODO: license header
-aiter_decode_templ = {
+suffix_source_dict = {
     '.hip': r"""// generated with aiter_decode_templ.py
+#include "pytorch_extension_utils.h"
+
+void {{kernel_name}}(
+    torch::Tensor& out, // [num_seqs, num_heads, head_size]
+    torch::Tensor& workspace_buffer,
+    torch::Tensor& query,       // [num_seqs, num_heads, head_size]
+    torch::Tensor& key_cache,   // [num_blocks, num_heads, block_size, head_size] or
+                                // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor& value_cache, // [num_blocks, num_heads, block_size, head_size] or
+                                // [num_blocks, block_size, num_heads, head_size]
+    double scale,
+    torch::Tensor& kv_indptr,         // [num_seqs + 1]
+    torch::Tensor& kv_page_indices,   // [max_num_blocks]
+    std::optional<torch::Tensor>& kv_last_page_lens, // [num_seqs]
+    int64_t block_size,
+    int64_t max_num_partitions,
+    const std::optional<torch::Tensor>& alibi_slopes,
+    const std::string& kv_cache_dtype,
+    const std::string& kv_cache_layout,
+    float logits_soft_cap,
+    torch::Tensor& k_scale,
+    torch::Tensor& v_scale,
+    const c10::optional<torch::Tensor>& fp8_out_scale,
+    int64_t partition_size) {
+
+    paged_attention_custom_launcher<
+        {{query_dtype}},
+        {{key_value_dtype}},
+        {{kvcache_dtype}},
+        {{block_size}},
+        {{head_size}},
+        {{out_dtype}},
+        {{partition_size_old}},
+        {{alibi_enabled}},
+        {{logits_soft_cap_enabled}}>(
+        out,
+        workspace_buffer,
+        query,
+        key_cache,
+        value_cache,
+        scale,
+        kv_indptr,
+        kv_page_indices,
+        kv_last_page_lens,
+        max_num_partitions,
+        alibi_slopes,
+        kv_cache_layout,
+        logits_soft_cap,
+        k_scale,
+        v_scale,
+        fp8_out_scale);
+}
 
 """,
     '_pybind.cc': r"""// generated with aiter_decode_templ.py
 #include "pytorch_extension_utils.h"
 
-void paged_attention(
+void {{kernel_name}}(
     torch::Tensor& out, // [num_seqs, num_heads, head_size]
     torch::Tensor& workspace_buffer,
     torch::Tensor& query,       // [num_seqs, num_heads, head_size]
@@ -30,7 +82,7 @@ void paged_attention(
     int64_t partition_size);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("run", &paged_attention,
+  m.def("run", &{{kernel_name}},
         "AITER paged attention");
 """,
 }

--- a/flashinfer/jit/aiter_decode_templ.py
+++ b/flashinfer/jit/aiter_decode_templ.py
@@ -3,26 +3,26 @@
 _FUNC_NAME = "paged_attention"
 
 _FUNC_ARGS = r"""
-    torch::Tensor& out, // [num_seqs, num_heads, head_size]
-    torch::Tensor& workspace_buffer,
-    torch::Tensor& query,       // [num_seqs, num_heads, head_size]
-    torch::Tensor& key_cache,   // [num_blocks, num_heads, block_size, head_size] or
+    at::Tensor& out, // [num_seqs, num_heads, head_size]
+    at::Tensor& workspace_buffer,
+    at::Tensor& query,       // [num_seqs, num_heads, head_size]
+    at::Tensor& key_cache,   // [num_blocks, num_heads, block_size, head_size] or
                                 // [num_blocks, block_size, num_heads, head_size]
-    torch::Tensor& value_cache, // [num_blocks, num_heads, block_size, head_size] or
+    at::Tensor& value_cache, // [num_blocks, num_heads, block_size, head_size] or
                                 // [num_blocks, block_size, num_heads, head_size]
     double scale,
-    torch::Tensor& kv_indptr,         // [num_seqs + 1]
-    torch::Tensor& kv_page_indices,   // [max_num_blocks]
-    std::optional<torch::Tensor>& kv_last_page_lens, // [num_seqs]
+    at::Tensor& kv_indptr,         // [num_seqs + 1]
+    at::Tensor& kv_page_indices,   // [max_num_blocks]
+    std::optional<at::Tensor>& kv_last_page_lens, // [num_seqs]
     int64_t block_size,
     int64_t max_num_partitions,
-    const std::optional<torch::Tensor>& alibi_slopes,
+    const std::optional<at::Tensor>& alibi_slopes,
     const std::string& kv_cache_dtype,
     const std::string& kv_cache_layout,
     float logits_soft_cap,
-    torch::Tensor& k_scale,
-    torch::Tensor& v_scale,
-    const c10::optional<torch::Tensor>& fp8_out_scale,
+    at::Tensor& k_scale,
+    at::Tensor& v_scale,
+    const c10::optional<at::Tensor>& fp8_out_scale,
     int64_t partition_size,
     int64_t stream
 """
@@ -1029,7 +1029,7 @@ void {{func_name}}({{func_args}}) {
 void {{func_name}}({{func_args}});
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("run", &{{func_name}},
-        "AITER paged attention");
+  m.def("run", &{{func_name}}, "AITER paged attention");
+}
 """,
 }

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -654,13 +654,27 @@ def get_aiter_decode_uri(*,
     )
 
 
+_aiter_default_kwargs = {
+    'dtype_q': torch.float16,
+    'dtype_kv': torch.float16,
+    'block_size': 1,
+    'head_size': 128,
+    'dtype_o': torch.float16,
+    'alibi_enabled': True,
+    'logits_soft_cap_enabled': True,
+    'gqa_ratio': 1,
+}
+
+
 def gen_aiter_decode_module(**kwargs):
-    from .aiter_decode_templ import suffix_template_dict, _FUNC_NAME, _FUNC_ARGS
+    from .aiter_decode_templ import suffix_template_dict, _FUNC_NAME, _FUNC_ARGS, _PAGED_ATTN_SRC, _REDUCE_SRC
     gen_directory = FLASHINFER_GEN_SRC_DIR
     uri = get_aiter_decode_uri(**kwargs)
     template_kwargs = {
         'func_name': _FUNC_NAME,
         'func_args': _FUNC_ARGS,
+        'paged_attn_kernel': _PAGED_ATTN_SRC,
+        'reduce_kernel': _REDUCE_SRC,
         'query_dtype': dtype_map[kwargs["dtype_q"]],
         'key_value_dtype': dtype_map[kwargs["dtype_kv"]],
         # 'kvcache_dtype': kwargs["dtype_kv"],

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -640,6 +640,10 @@ def get_aiter_decode_uri(*,
                          dtype_o: torch.dtype,
                          # dtype_idx: torch.dtype,
                          head_dim: int,
+                         block_size: int,
+                         alibi_enabled: bool,
+                         logits_soft_cap_enabled: bool,
+                         gqa_ratio: int,
                          # pos_encoding_mode: int,
                          # use_sliding_window: bool,
                          # use_logits_soft_cap: bool,
@@ -658,7 +662,7 @@ _aiter_default_kwargs = {
     'dtype_q': torch.float16,
     'dtype_kv': torch.float16,
     'block_size': 1,
-    'head_size': 128,
+    'head_dim': 128,
     'dtype_o': torch.float16,
     'alibi_enabled': True,
     'logits_soft_cap_enabled': True,
@@ -679,14 +683,14 @@ def gen_aiter_decode_module(**kwargs):
         'key_value_dtype': dtype_map[kwargs["dtype_kv"]],
         # 'kvcache_dtype': kwargs["dtype_kv"],
         'block_size': kwargs["block_size"],
-        'head_size': kwargs["head_size"],
+        'head_size': kwargs["head_dim"],
         'out_dtype': dtype_map[kwargs["dtype_o"]],
         'alibi_enabled': int(kwargs["alibi_enabled"]),
         'logits_soft_cap_enabled': int(kwargs["logits_soft_cap_enabled"]),
         'gqa_ratio': int(kwargs["gqa_ratio"])
     }
     paths_sources = [
-        ((gen_directory / f"{uri}{suffix}"), jinja2.Template(template).render(*template_kwargs))
+        ((gen_directory / f"{uri}{suffix}"), jinja2.Template(template).render(**template_kwargs))
         for suffix, template in suffix_template_dict.items()
     ]
     for path, source in paths_sources:

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -695,4 +695,4 @@ def gen_aiter_decode_module(**kwargs):
     ]
     for path, source in paths_sources:
         write_if_different(path, source)
-    return load_cuda_ops(uri, [source for _, source in paths_sources], verbose=True)
+    return load_cuda_ops(uri, [path for path, _ in paths_sources], verbose=True)

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -671,12 +671,13 @@ _aiter_default_kwargs = {
 
 
 def gen_aiter_decode_module(**kwargs):
-    from .aiter_decode_templ import suffix_template_dict, _FUNC_NAME, _FUNC_ARGS, _PAGED_ATTN_SRC, _REDUCE_SRC
+    from .aiter_decode_templ import suffix_template_dict, _FUNC_NAME, _FUNC_ARGS, _PAGED_ATTN_SRC, _REDUCE_SRC, _UTIL_SRC
     gen_directory = FLASHINFER_GEN_SRC_DIR
     uri = get_aiter_decode_uri(**kwargs)
     template_kwargs = {
         'func_name': _FUNC_NAME,
         'func_args': _FUNC_ARGS,
+        'util_src': _UTIL_SRC,
         'paged_attn_kernel': _PAGED_ATTN_SRC,
         'reduce_kernel': _REDUCE_SRC,
         'query_dtype': dtype_map[kwargs["dtype_q"]],

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -659,11 +659,11 @@ def get_aiter_decode_uri(*,
 
 
 _aiter_default_kwargs = {
-    'dtype_q': torch.float16,
-    'dtype_kv': torch.float16,
+    'dtype_q': torch.bfloat16,
+    'dtype_kv': torch.bfloat16,
     'block_size': 1,
     'head_dim': 128,
-    'dtype_o': torch.float16,
+    'dtype_o': torch.bfloat16,
     'alibi_enabled': True,
     'logits_soft_cap_enabled': True,
     'gqa_ratio': 1,

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -655,6 +655,10 @@ def get_aiter_decode_uri(*,
         f"dtype_kv_{filename_safe_dtype_map[dtype_kv]}_"
         f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
         f"head_dim_{head_dim}_"
+        f"page_size_{block_size}_"
+        f"alibi_enabled_{str(alibi_enabled)[0]}_"
+        f"logits_soft_cap_enabled_{str(logits_soft_cap_enabled)[0]}_"
+        f"gqa_ratio_{gqa_ratio}_"
     )
 
 

--- a/flashinfer/jit/attention.py
+++ b/flashinfer/jit/attention.py
@@ -661,15 +661,15 @@ def gen_aiter_decode_module(**kwargs):
     template_kwargs = {
         'func_name': _FUNC_NAME,
         'func_args': _FUNC_ARGS,
-        'query_dtype': kwargs["dtype_q"],
-        'key_value_dtype': kwargs["dtype_kv"],
-        'kvcache_dtype': kwargs["dtype_kv"],
+        'query_dtype': dtype_map[kwargs["dtype_q"]],
+        'key_value_dtype': dtype_map[kwargs["dtype_kv"]],
+        # 'kvcache_dtype': kwargs["dtype_kv"],
         'block_size': kwargs["block_size"],
         'head_size': kwargs["head_size"],
-        'out_dtype': kwargs["dtype_o"],
-        'partition_size_old': kwargs["partition_size_old"],
+        'out_dtype': dtype_map[kwargs["dtype_o"]],
         'alibi_enabled': int(kwargs["alibi_enabled"]),
         'logits_soft_cap_enabled': int(kwargs["logits_soft_cap_enabled"]),
+        'gqa_ratio': int(kwargs["gqa_ratio"])
     }
     paths_sources = [
         ((gen_directory / f"{uri}{suffix}"), jinja2.Template(template).render(*template_kwargs))

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -148,14 +148,13 @@ def load_cuda_ops(
     build_directory = FLASHINFER_JIT_DIR / name
     os.makedirs(build_directory, exist_ok=True)
     if extra_include_paths is None:
-        extra_include_paths = [
-            FLASHINFER_INCLUDE_DIR,
-            FLASHINFER_CSRC_DIR,
-        ]
-        if check_hip_availability():
-            extra_include_paths += []
-        elif check_cuda_availability():
-            extra_include_paths += CUTLASS_INCLUDE_DIRS
+        extra_include_paths = []
+    extra_include_paths += [
+        FLASHINFER_INCLUDE_DIR,
+        FLASHINFER_CSRC_DIR,
+    ]
+    if check_cuda_availability():
+        extra_include_paths += CUTLASS_INCLUDE_DIRS
     lock = FileLock(FLASHINFER_JIT_DIR / f"{name}.lock", thread_local=False)
     with lock:
         module = torch_cpp_ext.load(


### PR DESCRIPTION
Copied over kernels from https://github.com/ROCm/aiter/blob/testx/csrc/kernels/attention.cu as device functions, inlined the dependencies and added new wrappers

Testing:

```
# PYTORCH_ROCM_ARCH="native gfx90a gfx940 gfx941 gfx942" FLASHINFER_ENABLE_AOT=1 FLASHINFER_ENABLE_SM90=0 python setup.py develop
# rm -r /root/.cache/flashinfer/*
# python
>>> from flashinfer.jit.attention import _aiter_default_kwargs, gen_aiter_decode_module
>>> gen_aiter_decode_module(**_aiter_default_kwargs)
```

Then, the compilation should succeed with something like
```
2025-02-26 18:38:38,764 - INFO - flashinfer.jit: Finished loading JIT ops: aiter_decode_dtype_q_bf16_dtype_kv_bf16_dtype_o_bf16_head_dim_128_page_size_1_alibi_enabled_T_logits_soft_cap_enabled_T_gqa_ratio_1_
<module 'aiter_decode_dtype_q_bf16_dtype_kv_bf16_dtype_o_bf16_head_dim_128_page_size_1_alibi_enabled_T_logits_soft_cap_enabled_T_gqa_ratio_1_' from '/root/.cache/flashinfer/gfx1030_gfx1100_gfx1101_gfx1200_gfx1201_gfx908_gfx90a_gfx940_gfx941_gfx942/cached_ops/aiter_decode_dtype_q_bf16_dtype_kv_bf16_dtype_o_bf16_head_dim_128_page_size_1_alibi_enabled_T_logits_soft_cap_enabled_T_gqa_ratio_1_/aiter_decode_dtype_q_bf16_dtype_kv_bf16_dtype_o_bf16_head_dim_128_page_size_1_alibi_enabled_T_logits_soft_cap_enabled_T_gqa_ratio_1_.so'>
```

Caveat:

Some patching is needed to jit core for this way of testing, namely

```
$ git diff -- flashinfer/jit/core.py
diff --git a/flashinfer/jit/core.py b/flashinfer/jit/core.py
index 72a128c..8929205 100644
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -155,6 +155,9 @@ def load_cuda_ops(
     ]
     if check_cuda_availability():
         extra_include_paths += CUTLASS_INCLUDE_DIRS
+    extra_include_paths.append("/flashinfer/csrc/")
+    extra_include_paths.append("/flashinfer/include")
+    print(f"{extra_include_paths=}")
     lock = FileLock(FLASHINFER_JIT_DIR / f"{name}.lock", thread_local=False)
     with lock:
         module = torch_cpp_ext.load(
```